### PR TITLE
Implement `no_std` support with simplified `to_string`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ script:
   - cargo fmt --all -- --check
   - cargo build --verbose --all
   - cargo test --verbose --all
+  - cargo test --no-default-features --verbose --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1.0.105"
 toml = "0.7.6"
 
 [features]
+default = ["std"]
 arbitrary = ["dep:arbitrary"]
-default = []
+std = []
 serde = ["dep:serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,7 @@ fn to_string_decimal(bytes: u64, si_prefix: bool, f: &mut fmt::Formatter) -> fmt
     for (&size, &prefix) in unit_sizes.iter().zip(unit_prefix.iter()) {
         ideal_size = size;
         ideal_prefix = prefix;
-        if size <= bytes && bytes / 1_000 < size {
+        if size <= bytes && bytes / unit_sizes[0] < size {
             break;
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,14 +20,18 @@
 //! }
 //! ```
 //!
-//! It also provides its human readable string as follows:
-//!
-//! ```
-//! use bytesize::ByteSize;
-//!
-//! assert_eq!("482.4 GiB", ByteSize::gb(518).to_string_as(true));
-//! assert_eq!("518.0 GB", ByteSize::gb(518).to_string_as(false));
-//! ```
+#![cfg_attr(feature = "std", doc = r#"
+It also provides its human readable string as follows:
+
+```
+use bytesize::ByteSize;
+
+assert_eq!("482.4 GiB", ByteSize::gb(518).to_string_as(true));
+assert_eq!("518.0 GB", ByteSize::gb(518).to_string_as(false));
+```
+"#)]
+
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod parse;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,10 @@ mod parse;
 #[cfg(feature = "arbitrary")]
 extern crate arbitrary;
 
-#[cfg(any(feature = "std", not(all(not(feature = "std"), test))))]
-extern crate core;
+// Alias `std` as core when `std` is enabled
+#[cfg(feature = "std")]
+use std as core;
+// In tests bring in `std` even when `no_std`
 #[cfg(all(not(feature = "std"), test))]
 extern crate std;
 
@@ -44,7 +46,7 @@ extern crate std;
 extern crate serde;
 #[cfg(feature = "serde")]
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "std", feature = "serde"))]
 use std::convert::TryFrom;
 
 use core::fmt::{self, Debug, Display, Formatter};

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,5 +1,6 @@
 use super::ByteSize;
 
+#[cfg(feature = "std")]
 impl std::str::FromStr for ByteSize {
     type Err = String;
 
@@ -91,7 +92,7 @@ impl Unit {
 
 mod impl_ops {
     use super::Unit;
-    use std::ops;
+    use core::ops;
 
     impl ops::Add<u64> for Unit {
         type Output = u64;
@@ -158,6 +159,7 @@ mod impl_ops {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::str::FromStr for Unit {
     type Err = String;
 
@@ -181,7 +183,7 @@ impl std::str::FromStr for Unit {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
My attempt at resolving https://github.com/hyunsik/bytesize/issues/3.

Some things had to change. Firstly, in order to support alignment format specifiers we would have to write to a buffer and then `Formatter::pad` that. So we do not support alignment in `no_std`. I can add that if that is a requirement, but I felt that implementing the buffer would be a lot.

Also, the algorithm used to select the correct units had to change. `no_std` does not have access to complex math like `ln`. So we just manually check which unit is correct and go from there.

Nothing should be changed when `std` is enabled. These things are conditionally changed when the `std` feature is disabled.

If you test with `cargo test --no-default-features` it will run all the tests that can be run with `no_std`.

Oh! Also I put aside the parsing element. None of that is enabled when not using the standard library.