### PR TITLE
Add `as_usize` method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,11 @@ impl ByteSize {
     }
 
     #[inline(always)]
+    pub const fn as_usize(&self) -> usize {
+        self.0 as usize
+    }
+
+    #[inline(always)]
     pub fn to_string_as(&self, si_unit: bool) -> String {
         to_string(self.0, si_unit)
     }


### PR DESCRIPTION
I often see myself doing `Semaphore::new(capacity.as_u64() as usize)` where capacity is a `ByteSize`.