### PR TITLE
fix: backport fix from #59

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "bytesize"
 description = "an utility for human-readable bytes representations"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Hyunsik Choi <hyunsik.choi@gmail.com>"]
 
-homepage = "https://github.com/hyunsik/bytesize/"
+homepage = "https://github.com/bytesize-rs/bytesize/"
 documentation = "https://docs.rs/bytesize/"
-repository = "https://github.com/hyunsik/bytesize/"
+repository = "https://github.com/bytesize-rs/bytesize/"
 readme = "README.md"
 keywords = ["byte", "byte-size", "utility", "human-readable", "format"]
 license = "Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 //! ## Example
 //!
-//! ```ignore
+//! ```no_run
 //! extern crate bytesize;
 //!
 //! use bytesize::ByteSize;
@@ -14,17 +14,15 @@
 //!
 //!   let plus = x + y;
 //!   print!("{} bytes", plus.as_u64());
-//!
-//!   let minus = ByteSize::tb(100) - ByteSize::gb(4);
-//!   print!("{} bytes", minus.as_u64());
 //! }
 //! ```
 //!
 //! It also provides its human readable string as follows:
 //!
-//! ```ignore=
-//!  assert_eq!("482 GiB".to_string(), ByteSize::gb(518).to_string(true));
-//!  assert_eq!("518 GB".to_string(), ByteSize::gb(518).to_string(false));
+//! ```no_run
+//! # use bytesize::ByteSize;
+//! assert_eq!("482 GiB".to_string(), ByteSize::gb(518).to_string());
+//! assert_eq!("518 GB".to_string(), ByteSize::gb(518).to_string());
 //! ```
 
 mod parse;
@@ -208,7 +206,7 @@ pub fn to_string(bytes: u64, si_prefix: bool) -> String {
 }
 
 impl Display for ByteSize {
-    fn fmt(&self, f: &mut Formatter) ->fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.pad(&to_string(self.0, false))
     }
 }
@@ -261,7 +259,9 @@ impl AddAssign<ByteSize> for ByteSize {
 }
 
 impl<T> Add<T> for ByteSize
-    where T: Into<u64> {
+where
+    T: Into<u64>,
+{
     type Output = ByteSize;
     #[inline(always)]
     fn add(self, rhs: T) -> ByteSize {
@@ -270,7 +270,9 @@ impl<T> Add<T> for ByteSize
 }
 
 impl<T> AddAssign<T> for ByteSize
-    where T: Into<u64> {
+where
+    T: Into<u64>,
+{
     #[inline(always)]
     fn add_assign(&mut self, rhs: T) {
         self.0 += rhs.into() as u64;
@@ -278,7 +280,9 @@ impl<T> AddAssign<T> for ByteSize
 }
 
 impl<T> Mul<T> for ByteSize
-    where T: Into<u64> {
+where
+    T: Into<u64>,
+{
     type Output = ByteSize;
     #[inline(always)]
     fn mul(self, rhs: T) -> ByteSize {
@@ -287,7 +291,9 @@ impl<T> Mul<T> for ByteSize
 }
 
 impl<T> MulAssign<T> for ByteSize
-    where T: Into<u64> {
+where
+    T: Into<u64>,
+{
     #[inline(always)]
     fn mul_assign(&mut self, rhs: T) {
         self.0 *= rhs.into() as u64;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -10,9 +10,7 @@ impl std::str::FromStr for ByteSize {
         let number = take_while(value, |c| c.is_ascii_digit() || c == '.');
         match number.parse::<f64>() {
             Ok(v) => {
-                let suffix = skip_while(value, |c| {
-                    c.is_whitespace() || c.is_ascii_digit() || c == '.'
-                });
+                let suffix = skip_while(value, char::is_whitespace);
                 match suffix.parse::<Unit>() {
                     Ok(u) => Ok(Self((v * u) as u64)),
                     Err(error) => Err(format!(
@@ -220,6 +218,9 @@ mod tests {
 
         assert!(parse("").is_err());
         assert!(parse("a124GB").is_err());
+        assert!(parse("1.3 42.0 B").is_err());
+        assert!(parse("1.3 ... B").is_err());
+        assert!(parse("1 000 B").is_err());
     }
 
     #[test]


### PR DESCRIPTION
The fix in #59 seems mildly useful to roll out and could easily be released as v1.3.1 today? WDYT?

Since this branch is not the focus of our work, I changed as little as possible to prep this for release.

This PR is not intended to be merged but the branch can be kept in the repo for posterity.

also closes #17