### PR TITLE
chore: remove to_string_as method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,5 @@
 - Implement `SubAssign<ByteSize>` for `ByteSize`.
 - Implement `SubAssign<impl Into<u64>>` for `ByteSize`.
 - Reject parsing non-unit characters after whitespace.
+- Remove `ByteSize::to_string_as()` method.
+- Remove top-level `to_string()` method.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,7 @@
 //! ```
 //! use bytesize::ByteSize;
 //!
-//! assert_eq!("482.4 GiB", ByteSize::gb(518).to_string_as(false));
-//! assert_eq!("518.0 GB", ByteSize::gb(518).to_string_as(true));
+//! assert_eq!("482.4 GiB", ByteSize::gb(518).to_string());
 //! ```
 //!
 //! Arithmetic operations are supported.
@@ -199,15 +198,6 @@ impl ByteSize {
     pub const fn as_u64(&self) -> u64 {
         self.0
     }
-
-    #[inline(always)]
-    pub fn to_string_as(&self, si_unit: bool) -> String {
-        to_string(self.0, si_unit)
-    }
-}
-
-pub fn to_string(bytes: u64, si_unit: bool) -> String {
-    to_string_format(bytes, if si_unit { Format::SI } else { Format::IEC })
 }
 
 pub fn to_string_format(bytes: u64, format: Format) -> String {


### PR DESCRIPTION
the boolean parameter on this for IEC/SI selection is non-obvious

... instead we'll pursue something like #32 or #76