### PR TITLE
Add MSRV-version to for `1.x` release track

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/hyunsik/bytesize/"
 readme = "README.md"
 keywords = ["byte", "byte-size", "utility", "human-readable", "format"]
 license = "Apache-2.0"
+rust-version = "1.61"
 
 [dependencies]
 serde = { version = "1.0.185", optional = true }


### PR DESCRIPTION
I've noticed, that there is no MSRV specified for `1.x`-versions of this crate, which is unfortunate, as this prevents the MSRV-aware resolver of Cargo 1.84+ to check, whether the crate is available or not. Therefore this commit adds the missing meta-data.

I've selected Rust 1.61, since this is the lowest version, where `cargo build --features=serde` is successful:
```console
$ cargo +1.61 build --features=serde
   Compiling proc-macro2 v1.0.94
   Compiling unicode-ident v1.0.18
   Compiling serde v1.0.219
   Compiling quote v1.0.40
   Compiling syn v2.0.100
   Compiling serde_derive v1.0.219
   Compiling bytesize v1.3.0 (/home/jfrimmel/git/bytesize)
    Finished dev [unoptimized + debuginfo] target(s) in 7.27s
```