### PR TITLE
Configure docs.rs to build with all features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.70"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 default = ["std"]
 std = []


### PR DESCRIPTION
This makes it easier to look up e.g. the `serde` trait impls using the “source” links in the documentation.