### PR TITLE
ci: fix clippy linting errors (direct variable usage)

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -298,8 +298,8 @@ mod tests {
     #[test]
     fn precision() {
         let size = ByteSize::mib(1908);
-        assert_eq!("1.9 GiB".to_string(), format!("{}", size));
-        assert_eq!("2 GiB".to_string(), format!("{:.0}", size));
-        assert_eq!("1.86328 GiB".to_string(), format!("{:.5}", size));
+        assert_eq!("1.9 GiB".to_string(), format!("{size}"));
+        assert_eq!("2 GiB".to_string(), format!("{size:.0}"));
+        assert_eq!("1.86328 GiB".to_string(), format!("{size:.5}"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,7 +463,7 @@ mod tests {
 
     #[track_caller]
     fn assert_display(expected: &str, b: ByteSize) {
-        assert_eq!(expected, format!("{}", b));
+        assert_eq!(expected, format!("{b}"));
     }
 
     #[test]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -17,15 +17,11 @@ impl str::FromStr for ByteSize {
                 match suffix.parse::<Unit>() {
                     Ok(u) => Ok(Self((v * u) as u64)),
                     Err(error) => Err(format!(
-                        "couldn't parse {:?} into a known SI unit, {}",
-                        suffix, error
+                        "couldn't parse {suffix:?} into a known SI unit, {error}"
                     )),
                 }
             }
-            Err(error) => Err(format!(
-                "couldn't parse {:?} into a ByteSize, {}",
-                value, error
-            )),
+            Err(error) => Err(format!("couldn't parse {value:?} into a ByteSize, {error}")),
         }
     }
 }
@@ -177,7 +173,7 @@ impl str::FromStr for Unit {
             "gi" | "gib" => Ok(Self::GibiByte),
             "ti" | "tib" => Ok(Self::TebiByte),
             "pi" | "pib" => Ok(Self::PebiByte),
-            _ => Err(format!("couldn't parse unit of {:?}", unit)),
+            _ => Err(format!("couldn't parse unit of {unit:?}")),
         }
     }
 }


### PR DESCRIPTION
Fixes #102.

Fix clippy linting errors in CI/CD pipeline by using variables directly in `format!()`.