### PR TITLE
Add custom unit conversions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,10 +243,82 @@ impl ByteSize {
         ByteSize(size * EIB)
     }
 
-    /// Returns byte count.
+    /// Returns raw byte count.
     #[inline(always)]
     pub const fn as_u64(&self) -> u64 {
         self.0
+    }
+
+    /// Returns byte count as kilobytes.
+    #[inline(always)]
+    pub const fn as_kb(&self) -> f64 {
+        self.0 as f64 / KB as f64
+    }
+
+    /// Returns byte count as kibibytes.
+    #[inline(always)]
+    pub const fn as_kib(&self) -> f64 {
+        self.0 as f64 / KIB as f64
+    }
+
+    /// Returns byte count as megabytes.
+    #[inline(always)]
+    pub const fn as_mb(&self) -> f64 {
+        self.0 as f64 / MB as f64
+    }
+
+    /// Returns byte count as mebibytes.
+    #[inline(always)]
+    pub const fn as_mib(&self) -> f64 {
+        self.0 as f64 / MIB as f64
+    }
+
+    /// Returns byte count as gigabytes.
+    #[inline(always)]
+    pub const fn as_gb(&self) -> f64 {
+        self.0 as f64 / GB as f64
+    }
+
+    /// Returns byte count as gibibytes.
+    #[inline(always)]
+    pub const fn as_gib(&self) -> f64 {
+        self.0 as f64 / GIB as f64
+    }
+
+    /// Returns byte count as terabytes.
+    #[inline(always)]
+    pub const fn as_tb(&self) -> f64 {
+        self.0 as f64 / TB as f64
+    }
+
+    /// Returns byte count as tebibytes.
+    #[inline(always)]
+    pub const fn as_tib(&self) -> f64 {
+        self.0 as f64 / TIB as f64
+    }
+
+    /// Returns byte count as petabytes.
+    #[inline(always)]
+    pub const fn as_pb(&self) -> f64 {
+        self.0 as f64 / PB as f64
+    }
+
+    /// Returns byte count as pebibytes.
+    #[inline(always)]
+    pub const fn as_pib(&self) -> f64 {
+        self.0 as f64 / PB as f64
+    }
+
+    /// Returns byte count as exabytes.
+    #[inline(always)]
+    pub const fn as_eb(&self) -> f64 {
+        self.0 as f64 / EB as f64
+    }
+
+    /// Returns byte count as exbibytes.
+    #[inline(always)]
+    pub const fn as_eib(&self) -> f64 {
+        self.0 as f64 / EIB as f64
     }
 
     /// Returns a formatting display wrapper.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -560,6 +560,16 @@ mod tests {
         assert!(ByteSize::pib(1) < ByteSize::eb(1));
     }
 
+    #[test]
+    fn test_conversion() {
+        assert_eq!(ByteSize::gb(43).as_kib(), 41992187.5_f64);
+        assert_eq!(ByteSize::mib(27).as_gb(), 0.028311552_f64);
+        assert_eq!(ByteSize::tib(39).as_pib(), 0.042880953483264_f64);
+        assert_eq!(ByteSize::kib(938948).as_mb(), 961.482752_f64);
+        assert_eq!(ByteSize::pb(4837).as_eib(), 4.195428726649908_f64);
+        assert_eq!(ByteSize::b(2873872874893).as_tib(), 2.613772153284117_f64);
+    }
+
     #[track_caller]
     fn assert_display(expected: &str, b: ByteSize) {
         assert_eq!(expected, format!("{b}"));


### PR DESCRIPTION
Fixes #87. 
This PR adds custom unit conversions for all units that returns as `f64`. The following new methods are added:
- `as_kb()`
- `as_kib()`
- `as_mb()`
- `as_mib()`
- `as_gb()`
- `as_gib()`
- `as_tb()`
- `as_tib()`
- `as_pb()`
- `as_pib()`
- `as_eb()`
- `as_eib()`

Note that this has a lossy conversion for filesizes larger than `9_007_199_254_740_992` or `~9 PB`.