### PR TITLE
fix: honor precision when a width is set in ByteSize Display

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,40 @@ impl fmt::Display for ByteSize {
             // allocation-free fast path for when no formatting options are specified
             fmt::Display::fmt(&display, f)
         } else {
-            f.pad(&display.to_string())
+            // `display.to_string()` renders at the default precision, and `f.pad`
+            // reinterprets the formatter's precision as a *maximum* width. Together
+            // they drop the requested precision and truncate the value mid-unit
+            // (e.g. `{:>12.5}` rendered "1.86328 GiB" as "1.9 G"). Render with the
+            // requested precision first, then apply only the width, fill, and align.
+            let content = match f.precision() {
+                Some(precision) => alloc::format!("{display:.precision$}"),
+                None => display.to_string(),
+            };
+
+            let padding = f
+                .width()
+                .unwrap_or(0)
+                .saturating_sub(content.chars().count());
+            if padding == 0 {
+                return f.write_str(&content);
+            }
+
+            let (left, right) = match f.align() {
+                Some(fmt::Alignment::Right) => (padding, 0),
+                Some(fmt::Alignment::Center) => (padding / 2, padding - padding / 2),
+                Some(fmt::Alignment::Left) | None => (0, padding),
+            };
+
+            let mut buf = [0u8; 4];
+            let fill = f.fill().encode_utf8(&mut buf);
+            for _ in 0..left {
+                f.write_str(fill)?;
+            }
+            f.write_str(&content)?;
+            for _ in 0..right {
+                f.write_str(fill)?;
+            }
+            Ok(())
         }
     }
 }
@@ -664,5 +697,18 @@ mod alloc_tests {
         assert_eq!("|-----357 B|", format!("|{:->10}|", ByteSize(357)));
         assert_eq!("|357 B-----|", format!("|{:-<10}|", ByteSize(357)));
         assert_eq!("|--357 B---|", format!("|{:-^10}|", ByteSize(357)));
+    }
+    #[test]
+    fn test_display_width_with_precision() {
+        let size = ByteSize::mib(1908);
+        // Precision is honored as decimal places even when a width is given, and
+        // the rendered value is never truncated to satisfy the precision.
+        assert_eq!("| 1.86328 GiB|", format!("|{size:>12.5}|"));
+        assert_eq!("|1.86328 GiB |", format!("|{size:<12.5}|"));
+        assert_eq!("|1.86328 GiB |", format!("|{size:12.5}|"));
+        assert_eq!("|--1.86328 GiB--|", format!("|{size:-^15.5}|"));
+        assert_eq!("|     2 GiB|", format!("|{size:>10.0}|"));
+        // Width narrower than the value leaves it intact instead of truncating.
+        assert_eq!("1.86328 GiB", format!("{size:3.5}"));
     }
 }


### PR DESCRIPTION
When a `ByteSize` is formatted with a width, precision is dropped and the value can be truncated mid-unit:

```rust
format!("{:.5}", ByteSize::mib(1908));    // "1.86328 GiB"  (no width: precision honored)
format!("{:>12.5}", ByteSize::mib(1908)); // "       1.9 G"  (want " 1.86328 GiB")
```

The width branch of `Display` does `f.pad(&self.display().to_string())`. `to_string()` renders at the default precision (so `f.precision()` is ignored), and `f.pad` then interprets the precision as a *maximum* width and truncates the result — here `"1.9 GiB"` becomes `"1.9 G"`. The no-width fast path forwards the formatter and honors precision, and the existing `precision()` test pins precision to mean decimal places, so the width path is inconsistent with the rest of the crate.

This renders the value with the requested precision first, then applies only the width, fill, and alignment. Added `test_display_width_with_precision`; the existing `test_display_alignment` (including custom fill) still passes.

Checked: `cargo test`, `cargo test --no-default-features`, `cargo test --all-features`, `cargo fmt --check`, `cargo clippy --all-features` all clean.